### PR TITLE
Use cross-platform signal in tests

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -349,8 +348,7 @@ func (c *Consumer) ConsumeCtx(ctx context.Context, handler HandlerFunc) (err err
 func (c *Consumer) Consume(handler HandlerFunc, signals ...os.Signal) error {
 	if len(signals) == 0 {
 		signals = []os.Signal{
-			syscall.SIGINT,
-			syscall.SIGTERM,
+			os.Interrupt,
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mcmathja/curlyq/issues/1

This modifies the test to use `syscall.SIGALRM` as its test signal instead of `syscall.SIGUSR1`. The latter is only available on unix systems, while the former is available on Windows as well. It changes the tests to use `process.Signal` instead of `process.Kill` for similar reasons.